### PR TITLE
Eliminate all cookie usage, replacing with localStorage (Web Storage API)

### DIFF
--- a/src/js/language_switching.js
+++ b/src/js/language_switching.js
@@ -20,21 +20,6 @@ hd_language_switching.list_template = [
 	'</a>',
 	'</li>'].join('\n');
 
-function getCookie(cname) {
-    var name = cname + "=";
-    var ca = document.cookie.split(';');
-    for(var i = 0; i < ca.length; i++) {
-        var c = ca[i];
-        while (c.charAt(0) == ' ') {
-            c = c.substring(1);
-        }
-        if (c.indexOf(name) == 0) {
-            return c.substring(name.length, c.length);
-        }
-    }
-    return "";
-}
-
 $(document).ready(function() {
 	if (utils.hd_context.gi_languages.length) {
 		var list_data = {'items': []}

--- a/src/js/search.js
+++ b/src/js/search.js
@@ -167,10 +167,11 @@ function display_fragments_for_urls(fragments, token) {
 	}
 }
 
-function update_cookie() {
+function store_lang() {
   for (var i = 0; i < utils.hd_context.gi_languages.length; i++) {
     if ($(this).hasClass('search_result_' + utils.hd_context.gi_languages[i])) {
-      utils.setLanguageCookie(utils.hd_context.gi_languages[i]);
+      localStorage.setItem(
+        "hotdoc.gi-language", utils.hd_context.gi_languages[i]);
     }
   }
 }
@@ -308,7 +309,7 @@ function display_urls_for_token(data) {
 	}
 
 	token_results_div.html(meat);
-  token_results_div.on("click", "a[href]", update_cookie);
+  token_results_div.on("click", "a[href]", store_lang);
 
 	display_fragments_for_urls(final_urls, data.token);
 }

--- a/src/js/styleswitcher.js
+++ b/src/js/styleswitcher.js
@@ -1,4 +1,6 @@
 function setActiveStyleSheet(title) {
+  localStorage.setItem("hotdoc.style", title);
+
   var i, a;
   for(i=0; (a = document.getElementsByTagName("link")[i]); i++) {
     if (!a.hasAttribute('rel')) {
@@ -10,8 +12,6 @@ function setActiveStyleSheet(title) {
       if(a.getAttribute("title") == title) a.disabled = false;
     }
   }
-
-  setCookie("style", title, 365);
 
   const frame = document.getElementById('sitenav-frame');
 
@@ -70,8 +70,8 @@ function readCookie(name) {
 }
 
 function setPreferredStyleSheet() {
-  var cookie = readCookie("style");
-  var title = cookie ? cookie : getPreferredStyleSheet();
+  const stored = localStorage.getItem("hotdoc.style");
+  const title = stored ? stored : getPreferredStyleSheet();
   setActiveStyleSheet(title);
 }
 
@@ -84,9 +84,7 @@ window.onunload = function(e) {
   setCookie("style", title, 365);
 }
 
-var cookie = readCookie("style");
-var title = cookie ? cookie : getPreferredStyleSheet();
-setPreferredStyleSheet(title);
+setPreferredStyleSheet();
 
 $(document).ready(function() {
   $('#lightmode-icon').click(function() {

--- a/src/js/styleswitcher.js
+++ b/src/js/styleswitcher.js
@@ -48,27 +48,6 @@ function getPreferredStyleSheet() {
   return null;
 }
 
-function setCookie(name,value,days) {
-  if (days) {
-    var date = new Date();
-    date.setTime(date.getTime()+(days*24*60*60*1000));
-    var expires = "; expires="+date.toGMTString();
-  }
-  else expires = "";
-  document.cookie = name+"="+value+expires+"; path=/;SameSite=Strict";
-}
-
-function readCookie(name) {
-  var nameEQ = name + "=";
-  var ca = document.cookie.split(';');
-  for(var i=0;i < ca.length;i++) {
-    var c = ca[i];
-    while (c.charAt(0)==' ') c = c.substring(1,c.length);
-    if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length,c.length);
-  }
-  return null;
-}
-
 function setPreferredStyleSheet() {
   const stored = localStorage.getItem("hotdoc.style");
   const title = stored ? stored : getPreferredStyleSheet();
@@ -79,10 +58,10 @@ window.onload = function(e) {
   setPreferredStyleSheet();
 }
 
-window.onunload = function(e) {
-  var title = getActiveStyleSheet();
-  setCookie("style", title, 365);
-}
+// window.onunload = function(e) {
+//   var title = getActiveStyleSheet();
+//   localStorage.setItem("hodoc.style", title);
+// }
 
 setPreferredStyleSheet();
 

--- a/src/js/styleswitcher.js
+++ b/src/js/styleswitcher.js
@@ -1,5 +1,5 @@
 function setActiveStyleSheet(title) {
-  var i, a, main;
+  var i, a;
   for(i=0; (a = document.getElementsByTagName("link")[i]); i++) {
     if (!a.hasAttribute('rel')) {
       continue;

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -93,23 +93,13 @@ utils.uri_is_in_this_page = (function(uri) {
 	return utils.uri_is_in_page(utils.parseUri(window.location.href), uri);
 });
 
-utils.getLanguageCookie = (function () {
-    var name =  "gi-language=";
-    var ca = document.cookie.split(';');
-    for(var i = 0; i < ca.length; i++) {
-        var c = ca[i];
-        while (c.charAt(0) == ' ') {
-            c = c.substring(1);
-        }
-        if (c.indexOf(name) == 0) {
-            return c.substring(name.length, c.length);
-        }
-    }
-    return "c";
+utils.getStoredLanguage = (function () {
+    const lang = localStorage.getItem("hotdoc.gi-language");
+    return lang || "c";
 });
 
-utils.setLanguageCookie = (function (language) {
-    document.cookie = "gi-language=" + language + "; path=/;SameSite=Strict";
+utils.setStoredLanguage = (function (language) {
+    localStorage.setItem("hotdoc.gi-language", language);
 });
 
 utils.HDContext = (class {
@@ -136,8 +126,9 @@ utils.HDContext = (class {
 
     if (gi_languages_json) {
       this.gi_languages = JSON.parse(gi_languages_json.replace(/'/g, '"'));
-      this.gi_language = this.parsedUri.queries['gi-language'] || utils.getLanguageCookie() || 'c';
-      utils.setLanguageCookie(this.gi_language);
+      const query_language = this.parsedUri.queries['gi-language'];
+      this.gi_language = query_language || utils.getStoredLanguage() || 'c';
+      utils.setStoredLanguage(this.gi_language);
     } else {
       this.gi_languages = [];
     }


### PR DESCRIPTION
Users are growing increasingly distrustful of cookies. Understandably so: As information that's sent back to the server with every web request, they've become the primary vector for user tracking and collection of sensitive personal information by online advertisers and information brokers.

Even when cookies are used in completely innocent ways, as they are in hotdoc, they remain guilty by association with more objectionable uses.

Fortunately, there's a better way: the browser [Web Storage API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API), and specifically the `window.localStorage()` data store. Using `localStorage()`, a site can persist information in the user's browser for local access, without it being sent over the wire back to the remote server.

This PR replaces all use of cookies for data storage with calls to `localStorage.setItem()` and `localStorage.getItem()`. The selected language is stored as `hotdoc.gi-language`, and the style selection as `hotdoc.style`.

#### Caveats

No migration of values from the previous cookie storage is currently implemented, meaning that users' selections will be reset the first time they return to a site that's been upgraded from cookie-based persistence to `localStorage()`. However, that's at worst a minor inconvenience, and no different from the situation if they'd returned to the site after longer than 1 year's time. (The expiration time of the cookie data. `localStorage()` data does not expire, it will be retained indefinitely unless edited or deleted by the enduser.)

#### Implementation notes

As one of the commits in this PR notes, the `onunload`-driven updating of the selected stylesheet is still in the code (but converted from storing via cookies to using localStorage), however it's currently commented out. I can't see any reason it would be necessary with the new code, since updating the stored value is now the very _first_ thing `setActiveStyleSheet()` does. (The localStorage API doesn't have the same overhead as cookie management, so there's no reason not to be aggressive about storage updates.) That should make any kind of `onunload`-driven updating redundant/unnecessary.