### PR TITLE
Add human-readable names to search results

### DIFF
--- a/src/js/search.js
+++ b/src/js/search.js
@@ -182,7 +182,7 @@ search_result_template = [
   '<span class="search-match-type" data-hotdoc-node-type="{{{node_type}}}">',
   '<abbr title="{{{node_type_descr}}}"><span>{{{node_type_repr}}}</span></abbr>',
   '</span>',
-  '<a href="{{{url}}}" class="{{{extra_class}}}">{{{url}}}</a>',
+  '<a href="{{{url_href}}}" class="{{{extra_class}}}">{{url_text}}</a>',
   '<div search-id="{{{final_url}}}-fragment"></div>',
   '</div>'
 ].join('\n');
@@ -230,6 +230,28 @@ function get_url_node_type_descr (node_type) {
     return "Match found in text";
 }
 
+function get_url_node_text (url, root_url) {
+  var text = '';
+  if ('page' in url && url.page !== null) {
+    text += url.page;
+  }
+  if ('sections' in url && url.sections) {
+    for (var i = 0; i < url.sections.length; i++) {
+      if (text == url.sections[i]) {
+        continue;
+      }
+      if (text) {
+        text += " — ";
+      }
+      text += url.sections[i];
+    }
+  }
+  if (!text) {
+    text += root_url;
+  }
+  return text;
+}
+
 function display_urls_for_token(data) {
 	var token_results_div = $("#actual_search_results");
 
@@ -272,10 +294,12 @@ function display_urls_for_token(data) {
 
       var node_type_repr = get_url_node_type_repr(urls[i].node_type);
       var node_type_descr = get_url_node_type_descr(urls[i].node_type);
+      var url_text = get_url_node_text(urls[i], url);
 
       if (gi_languages.indexOf('default') != -1 || gi_languages.indexOf(utils.hd_context.gi_language) != -1) {
         meat += Mustache.to_html(search_result_template, {
-          'url': url,
+          'url_text': url_text,
+          'url_href': url,
           'extra_class': '',
           'final_url': final_url,
           'search_alert': '',
@@ -291,7 +315,8 @@ function display_urls_for_token(data) {
             'language': gi_languages[k].capitalizeFirstLetter(),
           });
           meat += Mustache.to_html(search_result_template, {
-            'url': url,
+            'url_text': url_text,
+            'url_href': url,
             'extra_class': 'search_result_' + gi_languages[k],
             'final_url': final_url,
             'search_alert': search_alert,


### PR DESCRIPTION
Use the new 'section' and 'page' fields from the search results to display URL links with easier to read names.

Depends on: https://github.com/hotdoc/hotdoc/pull/278

Below is an example before and after of search results from the Meson project documentation.

![meson-search-results-orig3](https://github.com/hotdoc/hotdoc_bootstrap_theme/assets/7141086/467b8796-c322-4ce3-8e34-518b580aa7f6)

![meson-search-results-new3](https://github.com/hotdoc/hotdoc_bootstrap_theme/assets/7141086/3fc85ea4-d45d-47b3-b206-326f7637b16e)
