### PR TITLE
enum-members: Fixes enum member search

### DIFF
--- a/src/templates/enum_member.html
+++ b/src/templates/enum_member.html
@@ -1,8 +1,8 @@
 @require(symbol, link, detail, value)
 
-<div class="symbol-detail" data-hotdoc-id="@link.id_">
+<div class="symbol-detail" id="@link.id_" data-hotdoc-id="@link.id_">
 	<div>
-		<i><em><code>@link.title</code></em></i>
+		<p><i><em><code>@link.title</code></em></i></p>
 		(<span class="value">@value</span>)
 		–
 	</div>


### PR DESCRIPTION
The enum constant names was not in the search token as it wasn't placed in a paragraph. Additionally, set an anchor, so the link have a place to point to.

This should allow searching and linking to enum constants.