### PR TITLE
meson: Add an offline build option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ hotdoc.generate_doc('some-doc-name',
 )
 ```
 
+#### Without internet access
+
+In some contexts, it is required to build the theme without internet access.
+In this case, use the `-Doffline=true` build option to disable the automatic
+`npm install` command. The build system will assume that all the files are
+already in place.
 
 ### Without meson
 

--- a/meson.build
+++ b/meson.build
@@ -2,13 +2,15 @@ project('hotdoc_bootstrap_theme', 'c')
 
 fs = import('fs')
 
-npm = find_program('npm', native: true)
 npm_files_dir = meson.current_source_dir() / 'node_modules'
-message('Running npm install…')
-res = run_command(
-    npm, 'install', meson.current_source_dir(),
-    check: true,
-)
+if not get_option('offline')
+	npm = find_program('npm', native: true)
+	message('Running npm install…')
+	res = run_command(
+	    npm, 'install', meson.current_source_dir(),
+	    check: true,
+	)
+endif
 
 less = find_program('lessc', dirs: [meson.current_source_dir() / 'node_modules/less/bin/'], native: true)
 if get_option('less_include_path') != ''

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,3 @@
-option('less_include_path', type : 'string', value : '')
-option('install', type : 'boolean', value : false)
+option('less_include_path', type : 'string', value : '', description : 'Optional include path given to less')
+option('install', type : 'boolean', value : false, description : 'Install the theme')
+option('offline', type : 'boolean', value : false, description : 'Avoid online operations like npm install')


### PR DESCRIPTION
Allows to build the project with pre-installed dependencies (without forced npm install)
Based on #28